### PR TITLE
Change jsx-filename-extension rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,6 @@ module.exports = {
     'jsx-a11y/no-static-element-interactions': 0,
     'react/no-unused-prop-types': 0,
     'react/forbid-prop-types': 0,
+    'react/jsx-filename-extension': ['error', { extensions: ['.js'] }],
   },
 };


### PR DESCRIPTION
As decided we'll allow `.js` extension instead of `.jsx`, hence deprecating `.jsx` completely.