### PR TITLE
WIP: Add rule to restrict certain file extensions

### DIFF
--- a/rules/no-specific-file-extensions.js
+++ b/rules/no-specific-file-extensions.js
@@ -10,7 +10,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Restrict specific file extensions',
-      category: 'Stylistic Issues',
+      category: 'Best Practices',
       recommended: false
     },
 

--- a/rules/no-specific-file-extensions.js
+++ b/rules/no-specific-file-extensions.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const path = require('path');
+
+const DEFAULTS = {
+  extensions: ['.jsx']
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Restrict specific file extensions',
+      category: 'Stylistic Issues',
+      recommended: false
+    },
+
+    schema: [{
+      type: 'object',
+      properties: {
+        extensions: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      },
+      additionalProperties: false
+    }]
+  },
+
+  create: function(context) {
+    function getExtensionsConfig() {
+      return context.options[0] && context.options[0].extensions || DEFAULTS.extensions;
+    }
+
+    return {
+      Program: function(node) {
+        const filename = context.getFilename();
+
+        if (filename === '<text>') {
+          return;
+        }
+
+        const extension = path.extname(filename);
+        const allowedExtensions = getExtensionsConfig();
+        const isRestrictedExtension = allowedExtensions.includes(extension);
+
+        if (!isRestrictedExtension) {
+          return;
+        }
+
+        context.report({
+          node: node,
+          message: `File extension '${extension}' not allowed.`
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
ESLint rule that shows an error if specific file extensions (determined by the developer) are being used.

## Usage

Eslint must be called specifying the rules directory with `--rulesdir`. 
Usage (open to ideas):

*package.json*
```bash
eslint --rulesdir ./node_modules/eslint-config-picter/rules --ext .jsx --ext .js src
```

*.eslint.yaml*
```yaml
rules:
    no-specific-file-extensions:
      - error
      -
        extensions:
          - .jsx
```