### PR TITLE
Disable import/no-named-as-default rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
       ]
     }],
     'import/prefer-default-export': 0,
+    'import/no-named-as-default': 0,
     'jsx-a11y/no-static-element-interactions': 0,
     'react/no-unused-prop-types': 0,
     'react/forbid-prop-types': 0,


### PR DESCRIPTION
To allow named exports of pure components and using default export for connected components.

```
export class Component {
}

export default connect(...)(Component);
```